### PR TITLE
Drop explicit "rails" dependency in favour of slimmer "railties"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+## 1.1.1 - 2021-03-25
+
+ * Replace dependency on `rails` with a more specific dependency on `railties` and friends
+
 ## 1.1.0 - 2021-01-05
 
 - Ensure compability with Ruby 3.0 and Ruby on Rails 6.1

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in zaikio-loom.gemspec
 gemspec
+
+gem "actionpack"
+gem "actionview"
+gem "activemodel"
+gem "sprockets-rails"

--- a/lib/zaikio/loom/version.rb
+++ b/lib/zaikio/loom/version.rb
@@ -1,5 +1,5 @@
 module Zaikio
   module Loom
-    VERSION = "1.1.0".freeze
+    VERSION = "1.1.1".freeze
   end
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -1,6 +1,6 @@
 require_relative 'boot'
 
-require "rails"
+# require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"
 require "active_job/railtie"

--- a/zaikio-loom.gemspec
+++ b/zaikio-loom.gemspec
@@ -23,8 +23,9 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "activejob"
   spec.add_dependency "nokogiri", ">= 1.11.0"
-  spec.add_dependency "rails", "~> 6.0", ">= 6.0.2.3"
+  spec.add_dependency "railties", "~> 6.0", ">= 6.0.2.3"
   spec.add_runtime_dependency "oj"
   spec.required_ruby_version = ">= 2.7.1"
 


### PR DESCRIPTION
The [mimemagic incident](https://twitter.com/nateberkopec/status/1374722404228853762) has shown that it's always good to require as few dependencies as possible. A Rails Engine only needs the `railties` gem, plus whatever else it does internally, so instead of pulling in the whole of Rails for our gem we can just pick and choose the parts we want.