### PR TITLE
Ignore subject not found errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Ignore `"subject":["not found"]` errors
+- Log responses
+
 ## 1.3.0 - 2021-11-22
 
 - Support configuration of `queue` for FireEventJob

--- a/lib/zaikio/loom/error.rb
+++ b/lib/zaikio/loom/error.rb
@@ -2,10 +2,10 @@ module Zaikio
   module Loom
     class Error < StandardError
       attr_reader :body, :status_code
-      
+
       def initialize(message = nil, body:, status_code:)
         super(message)
-        
+
         @body = body
         @status_code = status_code
       end

--- a/lib/zaikio/loom/event.rb
+++ b/lib/zaikio/loom/event.rb
@@ -36,11 +36,13 @@ module Zaikio
 
         @status_code   = response.code.to_i
         @response_body = response.body
+        log_response
 
-        unless response.is_a?(Net::HTTPSuccess)
+        if !response.is_a?(Net::HTTPSuccess) && !(@status_code == 422 &&
+          JSON.parse(@response_body).dig("errors", "subject")&.include?("not found"))
           raise Zaikio::Loom::Error.new(
             "Sending event failed (#{@status_code}): #{@response_body}",
-            body: @response_body,
+            body:        @response_body,
             status_code: @status_code
           )
         end
@@ -91,6 +93,10 @@ module Zaikio
 
       def log_event
         configuration.logger.info("Zaikio::Loom event\n#{event_as_json}")
+      end
+
+      def log_response
+        configuration.logger.info("Zaikio::Loom event\n#{@id}\n#{@status_code}\n#{@response_body}")
       end
     end
   end

--- a/test/zaikio/loom/event_test.rb
+++ b/test/zaikio/loom/event_test.rb
@@ -80,4 +80,12 @@ class Zaikio::Loom::EventTest < Minitest::Test
       event.fire
     end
   end
+
+  def test_that_it_ignore_subject_not_found
+    stub_request(:post, "http://loom.zaikio.test/api/v1/events")
+      .to_return(status: 422, body: "{\"errors\":{\"subject\":[\"not found\"]}}", headers: {})
+
+    refute event.fire
+    assert_equal 422, event.status_code
+  end
 end


### PR DESCRIPTION
It might be that when an event is sent in the background that the subject does not exist anymore. Since it will retry to send this event over and over, these rare cases lead to a lot of noise. Since this errors is very possible I would like to change this globally instead of configuring this in each project.