### PR TITLE
Support staging environment to allow internal testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Support `staging` environment to allow internal testing
+
 ## 1.3.1 - 2022-01-07
 
 - Permit Rails 7

--- a/lib/zaikio/loom/configuration.rb
+++ b/lib/zaikio/loom/configuration.rb
@@ -5,6 +5,7 @@ module Zaikio
     class Configuration
       HOSTS = {
         test:       "http://loom.zaikio.test",
+        staging:    "https://loom.staging.zaikio.com",
         sandbox:    "https://loom.sandbox.zaikio.com",
         production: "https://loom.zaikio.com"
       }.freeze

--- a/test/zaikio/loom/event_test.rb
+++ b/test/zaikio/loom/event_test.rb
@@ -64,7 +64,7 @@ class Zaikio::Loom::EventTest < Minitest::Test
   end
 
   def test_that_it_does_not_fail_in_unknown_environments
-    Zaikio::Loom.configuration.environment = :staging
+    Zaikio::Loom.configuration.environment = :unknown
 
     refute event.fire
 


### PR DESCRIPTION
This partly reverts https://github.com/zaikio/zaikio-loom-ruby/pull/14

There is no good reason to me why we should forbid the staging environment. Esp. when testing hub <-> loom on staging it is essential that we are able to send events from the hub. Though it should only be used internally by us.